### PR TITLE
Hotfix/v2.7.5 to main

### DIFF
--- a/DIMS/CollectFilled.R
+++ b/DIMS/CollectFilled.R
@@ -28,6 +28,8 @@ for (scanmode in scanmodes) {
   # calculate Z-scores
   if (z_score == 1) {
     outlist_stats <- calculate_zscores_peakgrouplist(outlist_total)
+  } else {
+    outlist_stats <- outlist_total
   }
   # calculate ppm deviation
   outlist_withppm <- calculate_ppm_deviation(outlist_stats)

--- a/DIMS/GenerateQCOutput.R
+++ b/DIMS/GenerateQCOutput.R
@@ -37,9 +37,11 @@ dir.create(paste0(outdir, "/plots"), showWarnings = FALSE)
 control_label <- "C"
 
 #### CHECK NUMBER OF CONTROLS ####
-file_name <- "Check_number_of_controls.txt"
-min_num_controls <- 25
-check_number_of_controls(outlist, min_num_controls, file_name)
+if (any(grepl("nr_ctrls", colnames(outlist)))) {
+  file_name <- "Check_number_of_controls.txt"
+  min_num_controls <- 25
+  check_number_of_controls(outlist, min_num_controls, file_name)
+}
 
 #### INTERNAL STANDARDS ####
 is_list <- outlist[grep("Internal standard", outlist[, "relevance"], fixed = TRUE), ]

--- a/DIMS/export/generate_violin_plots_functions.R
+++ b/DIMS/export/generate_violin_plots_functions.R
@@ -67,6 +67,12 @@ add_zscores_ratios_to_df <- function(outlist, metabolites_ratios_df, all_sample_
 #'
 #' @returns zscore_ratios_df: dataframe containing Z-scores for all ratios for all samples
 calculate_zscore_ratios <- function(metabolites_ratios_df, intensities_zscores_df, intensity_col_names) {
+  # remove Z-score columns from intensity_col_names
+  if (any(grepl("_Zscore", intensity_col_names))) {
+    intensity_col_names <- intensity_col_names[-grep("_Zscore", intensity_col_names)]
+  }
+
+  # create empty data frame for results
   zscore_ratios_df <- data.frame(matrix(
     ncol = ncol(intensities_zscores_df),
     nrow = nrow(metabolites_ratios_df)

--- a/DIMS/export/generate_violin_plots_functions.R
+++ b/DIMS/export/generate_violin_plots_functions.R
@@ -665,13 +665,19 @@ create_pdf_violin_plots <- function(pdf_dir, patient_id, metab_perpage, top_meta
   for (metab_class in names(metab_perpage)) {
     # extract list of metabolites to plot on a page
     metab_zscores_df <- metab_perpage[[metab_class]]
-    # extract original data for patient of interest (pt_name) before cut-offs
-    patient_zscore_df <- metab_zscores_df %>% filter(Sample == patient_id)
-
-    # Remove patient column and change Z-score. If under -5 to -5 and if above 20 to 20.
+    # copy Z-scores to Z_score_original for displaying values
+    metab_zscores_df$Z_score_original <- metab_zscores_df$Z_score
+    # Cap Z-scores under -5 to -5 and above 20 to 20
     metab_zscores_df <- metab_zscores_df %>%
-      filter(Sample != patient_id) %>%
       mutate(Z_score = pmin(pmax(Z_score, -5), 20))
+
+    # extract original data for patient of interest (pt_name)
+    patient_zscore_df <- metab_zscores_df %>%
+      filter(Sample == patient_id)
+
+    # Remove patient of interest and retain only other patient data
+    metab_zscores_df <- metab_zscores_df %>%
+      filter(Sample != patient_id)
 
     # subtitle per page
     sub_perpage <- gsub("_", " ", metab_class)
@@ -733,7 +739,7 @@ create_violin_plot <- function(metab_zscores_df, patient_zscore_df, sub_perpage,
     # Add the Z-score at the right side of the plot
     geom_text(
       data = patient_zscore_df,
-      aes(16, label = paste0("Z=", round(Z_score, 2))),
+      aes(16, label = paste0("Z=", round(Z_score_original, 2))),
       hjust = "left", vjust = +0.2, size = 3, na.rm = TRUE
     ) +
     # Set colour for the Z-score of the selected patient

--- a/DIMS/preprocessing/collect_filled_functions.R
+++ b/DIMS/preprocessing/collect_filled_functions.R
@@ -129,9 +129,13 @@ order_columns_peakgrouplist <- function(peakgroup_list) {
   
   original_colnames <- colnames(peakgroup_list)
   mass_columns <- c(grep("mzm", original_colnames), grep("nrsamples", original_colnames))
-  descriptive_columns <- grep("assi_HMDB", original_colnames):grep("avg.int", original_colnames)
+  if (any(grepl("avg.int", original_colnames))) {
+    descriptive_columns <- grep("assi_HMDB", original_colnames):grep("avg.int", original_colnames)
+  } else {
+    descriptive_columns <- grep("assi_HMDB", original_colnames):grep("ppmdev", original_colnames)
+  }
   intensity_columns <- c((grep("nrsamples", original_colnames) + 1):(grep("assi_HMDB", original_colnames) - 1))
-  # if no Z-scores have been calculated, the following two variables will be empty without consequences for outlist_total
+  # if no Z-scores have been calculated, the following two variables will be empty without consequences for peakgroup_list
   control_columns <- grep ("ctrls", original_colnames)
   zscore_columns <- grep("_Zscore", original_colnames)
   # create peak group list with columns in correct order

--- a/DIMS/preprocessing/sum_intensities_adducts.R
+++ b/DIMS/preprocessing/sum_intensities_adducts.R
@@ -32,8 +32,8 @@ sum_intensities_adducts <- function(peakgroup_list, hmdb_part, adducts, z_score)
     int_cols_pats <- grep("P", colnames(peakgroup_list)[1:which(colnames(peakgroup_list) == "avg.ctrls")])
     int_cols <- c(int_cols_ctrls, int_cols_pats)
   } else {
-    int_cols_start <- which(colnames(peakgroup_list) == "nrsamples") + 1
-    int_cols_end <- which(colnames(peakgroup_list) == "assi_HMDB") - 1
+    int_cols_start <- which(colnames(peakgroup_list) == "ppmdev") + 1
+    int_cols_end <- ncol(peakgroup_list)
     int_cols <- c(int_cols_start:int_cols_end)
   }
 

--- a/DIMS/tests/testthat/fixtures/test_acyl_carnitines_df.txt
+++ b/DIMS/tests/testthat/fixtures/test_acyl_carnitines_df.txt
@@ -1,21 +1,21 @@
-HMDB_name	Sample	Z_score
-metab1                                       	P2025M1	0.31
-metab3                                       	P2025M1	2.34
-metab1                                       	P2025M2	2.45
-metab3                                       	P2025M2	1.45
-metab1                                       	P2025M3	2.14
-metab3                                       	P2025M3	-1.44
-metab1                                       	P2025M4	12.18
-metab3                                       	P2025M4	-0.18
-metab1                                       	P2025M5	3.22
-metab3                                       	P2025M5	-3.18
-metab1                                       	C101.1	0.45
-metab3                                       	C101.1	-1.86
-metab1                                       	C102.1	2.89
-metab3                                       	C102.1	-1.88
-metab1                                       	C103.1	0.54
-metab3                                       	C103.1	1.58
-metab1                                       	C104.1	0.53
-metab3                                       	C104.1	0.35
-metab1                                       	C105.1	3.46
-metab3                                       	C105.1	0.14
+HMDB_name	Sample	Z_score	Z_score_original
+metab1                                       	P2025M1	0.31	0.31
+metab3                                       	P2025M1	2.34	2.34
+metab1                                       	P2025M2	2.45	2.45
+metab3                                       	P2025M2	1.45	1.45
+metab1                                       	P2025M3	2.14	2.14
+metab3                                       	P2025M3	-1.44	-1.44
+metab1                                       	P2025M4	12.18	12.18
+metab3                                       	P2025M4	-0.18	-0.18
+metab1                                       	P2025M5	3.22	3.22
+metab3                                       	P2025M5	-3.18	-3.18
+metab1                                       	C101.1	0.45	0.45
+metab3                                       	C101.1	-1.86	-1.86
+metab1                                       	C102.1	2.89	2.89
+metab3                                       	C102.1	-1.88	-1.88
+metab1                                       	C103.1	0.54	0.54
+metab3                                       	C103.1	1.58	1.58
+metab1                                       	C104.1	0.53	0.53
+metab3                                       	C104.1	0.35	0.35
+metab1                                       	C105.1	3.46	3.46
+metab3                                       	C105.1	0.14	0.14


### PR DESCRIPTION
Hotfix v2.7.5 for DIMS:
- fixed empty violin plots
- fixed calculation of Z-scores for ratios
- fixed bug for research datasets where z_score = 0